### PR TITLE
Fix Button element and SectionBlock

### DIFF
--- a/Peaky.Slack.BlockKit/Elements/ButtonElement.cs
+++ b/Peaky.Slack.BlockKit/Elements/ButtonElement.cs
@@ -9,7 +9,7 @@ namespace Peaky.Slack.BlockKit.Elements
         /// <summary>
         /// The type of element. In this case type is always button.
         /// </summary>
-        [JsonProperty("button")]
+        [JsonProperty("type")]
         public string Type => "button";
 
         /// <summary>

--- a/Peaky.Slack.BlockKit/Layout/SectionBlock.cs
+++ b/Peaky.Slack.BlockKit/Layout/SectionBlock.cs
@@ -12,12 +12,12 @@ namespace Peaky.Slack.BlockKit.Layout
         /// </summary>
         [JsonProperty("type")]
         public string Type => "section";
-        
+
         /// <summary>
         /// The text for the block, in the form of a text object.
         /// Maximum length for the text in this field is 3000 characters.
         /// </summary>
-        [JsonProperty("text")]
+        [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public TextComposition Text;
 
         /// <summary>


### PR DESCRIPTION
- The name of the type property on a ButtonElement is "button" but it should be "type". Now this is fixed.
- If a SectionBlock is created and no text is set. A null text is set. This causes an error when sending the message. It is now ignored.